### PR TITLE
On permission denied show user message accordingly

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -108,7 +108,12 @@ func callbackController(a *App) gin.HandlerFunc {
 				"token": rawIDToken,
 			})
 		} else {
-			c.Writer.WriteString("permission denied")
+			_, err := c.Writer.WriteString("permission denied")
+			if err != nil {
+				log.Errorf("unable to write response to user")
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
 			c.Status(http.StatusUnauthorized)
 		}
 	}

--- a/connect.go
+++ b/connect.go
@@ -108,7 +108,8 @@ func callbackController(a *App) gin.HandlerFunc {
 				"token": rawIDToken,
 			})
 		} else {
-			c.AbortWithStatus(http.StatusUnauthorized)
+			c.Writer.WriteString("permission denied")
+			c.Status(http.StatusUnauthorized)
 		}
 	}
 }


### PR DESCRIPTION
Show the user some feedback instead of a blank screen, which signaled a page crash or something similar, which was not the case.