### PR TITLE
Avoid looking up empty redirect path

### DIFF
--- a/redirect.go
+++ b/redirect.go
@@ -23,6 +23,7 @@ func redirect(a *App) gin.HandlerFunc {
 
 		if path == "" || path == "/" {
 			c.Redirect(http.StatusFound, a.Config.EmptyRedirect)
+			return
 		}
 
 		linkPath := strings.ToLower(path)


### PR DESCRIPTION
Causes errors such as:
`time="2022-02-21T21:05:55Z" level=error msg="unable to retrieve link: '/', error: record not found"`